### PR TITLE
add configurable timeouts, uniform timeout-names

### DIFF
--- a/raiden/app.py
+++ b/raiden/app.py
@@ -25,14 +25,17 @@ class App(object):  # pylint: disable=too-few-public-methods
         host='',
         port=INITIAL_PORT,
         privkey='',
-        min_locktime=10,
+        # timespan a node requires to learn the secret before the lock expires for him (time in #blocks):
+        reveal_timeout=3,
+        # how long to wait for a transfer until CancelTransfer is sent (time in milliseconds):
+        msg_timeout=100.00
     )
 
     def __init__(self, config, chain, discovery, transport_class=UDPTransport):
         self.config = config
         self.discovery = discovery
         self.transport = transport_class(config['host'], config['port'])
-        self.raiden = RaidenService(chain, config['privkey'], self.transport, discovery)
+        self.raiden = RaidenService(chain, config['privkey'], self.transport, discovery, config)
 
         discovery.register(self.raiden.address, self.transport.host, self.transport.port)
 
@@ -87,7 +90,7 @@ def main():
     app = App(config, blockchain_server, discovery)
 
     for asset_address in blockchain_server.asset_addresses:
-        app.raiden.setup_asset(asset_address, app.config['min_locktime'])
+        app.raiden.setup_asset(asset_address, app.config['reveal_timeout'])
 
     # TODO:
     # - Ask for confirmation to quit if there are any locked transfers that did

--- a/raiden/benchmark/speed_simulation.py
+++ b/raiden/benchmark/speed_simulation.py
@@ -145,7 +145,7 @@ def tps_run(host, port, config, rpc_server, channelmanager_address,
     app = App(config, blockchain_service, discovery)
 
     for asset_address in blockchain_service.asset_addresses:
-        app.raiden.setup_asset(asset_address, app.config['min_locktime'])
+        app.raiden.setup_asset(asset_address, app.config['reveal_timout'])
 
     for _ in range(parallel):
         gevent.spawn(random_transfer, app, asset_address, transfer_amount)

--- a/raiden/blockchain/net_contract.py
+++ b/raiden/blockchain/net_contract.py
@@ -137,17 +137,17 @@ class NettingChannelContract(object):
         testing.
     """
 
-    # The locked_time could be either fixed or variable:
+    # The settle_timeout could be either fixed or variable:
     #
     # - For the fixed scenario, the application must not accept any locked
-    # transfers that could expire after `locked_time` blocks, at the cost of
+    # transfers that could expire after `settle_timeout` blocks, at the cost of
     # being susceptible to timming attacks.
-    # - For the variable scenario, the `locked_time` would depend on the locked
+    # - For the variable scenario, the `settle_timeout` would depend on the locked
     # transfer and to determine it's value a list of all the locks need to be
     # sent to the contract.
     #
     # This implementation uses a fixed lock time
-    locked_time = 20
+    settle_timeout = 20
     """ Number of blocks that we are required to wait before allowing settlement. """
 
     def __init__(self, asset_address, netcontract_address, address_A, address_B):
@@ -344,7 +344,7 @@ class NettingChannelContract(object):
         assert not self.settled
         # during testing closed can be 0 and it is falsy
         assert self.closed is not None
-        assert self.closed + self.locked_time <= ctx['block_number']
+        assert self.closed + self.settle_timeout <= ctx['block_number']
 
         for address, state in self.participants.items():
             other = self.participants[self.partner(address)]

--- a/raiden/channel.py
+++ b/raiden/channel.py
@@ -405,7 +405,7 @@ class Channel(object):
             # As a receiver: If the lock expiration is larger than the settling
             # time a secret could be revealed after the channel is settled and
             # we won't be able to claim the asset
-            if transfer.lock.expiration - self.chain.block_number >= self.settle_timeout:
+            if not transfer.lock.expiration - self.chain.block_number < self.settle_timeout:
                 log.error(
                     "Transfer expiration doesn't allow for correct settlement.",
                     transfer_expiration_block=transfer.lock.expiration,
@@ -415,7 +415,7 @@ class Channel(object):
 
                 raise ValueError("Transfer expiration doesn't allow for correct settlement.")
 
-            if transfer.lock.expiration - self.chain.block_number > self.reveal_timeout:
+            if not transfer.lock.expiration - self.chain.block_number > self.reveal_timeout:
                 log.error(
                     'Expiration smaller than the minimum required.',
                     transfer_expiration_block=transfer.lock.expiration,

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -85,9 +85,10 @@ class RaidenService(object):
 
     """ Runs a service on a node """
 
-    def __init__(self, chain, privkey, transport, discovery):
+    def __init__(self, chain, privkey, transport, discovery, config):
         self.chain = chain
-        self.privkey = privkey
+        self.config = config
+        self.privkey = privkey  # or config['privkey']
         self.address = privtoaddr(privkey)
         self.protocol = RaidenProtocol(transport, discovery, self)
         transport.protocol = self.protocol
@@ -97,14 +98,14 @@ class RaidenService(object):
     def __repr__(self):
         return '<{} {}>'.format(self.__class__.__name__, pex(self.address))
 
-    def setup_asset(self, asset_address, min_locktime):
+    def setup_asset(self, asset_address, reveal_timeout):
         """ Initialize a `AssetManager`, and for each open channel that this
         node has create a corresponding `Channel`.
 
         Args:
             asset_address (address): A list of asset addresses that need to
                 be considered.
-            min_locktime (int): Minimum number of blocks required for the
+            reveal_timeout (int): Minimum number of blocks required for the
                 settling of a netting contract.
         """
         netting_address = self.chain.nettingaddresses_by_asset_participant(
@@ -119,7 +120,7 @@ class RaidenService(object):
                 asset_manager,
                 asset_address,
                 nettingcontract_address,
-                min_locktime,
+                reveal_timeout,
             )
 
     def get_or_create_asset_manager(self, asset_address):
@@ -133,7 +134,7 @@ class RaidenService(object):
 
         return self.assetmanagers[asset_address]
 
-    def setup_channel(self, asset_manager, asset_address, nettingcontract_address, min_locktime):
+    def setup_channel(self, asset_manager, asset_address, nettingcontract_address, reveal_timeout):
         """ Initialize the Channel for the given netting contract. """
 
         channel_details = self.chain.netting_contract_detail(
@@ -158,7 +159,7 @@ class RaidenService(object):
             nettingcontract_address,
             our_state,
             partner_state,
-            min_locktime=min_locktime,
+            reveal_timeout,
         )
 
         asset_manager.add_channel(channel_details['partner_address'], channel)

--- a/raiden/tests/test_channel.py
+++ b/raiden/tests/test_channel.py
@@ -107,7 +107,7 @@ def test_locked_transfer():
     balance1 = channel1.balance
 
     amount = 10
-    expiration = app0.raiden.chain.block_number + 15  # min_locktime <= expiration < contract.lock_time
+    expiration = app0.raiden.chain.block_number + 15  # reveal_timeout <= expiration < contract.lock_time
 
     secret = 'secret'
     hashlock = sha3(secret)

--- a/raiden/tests/test_settlement.py
+++ b/raiden/tests/test_settlement.py
@@ -77,7 +77,7 @@ def test_settlement():
         unlocked,
     )
 
-    for _ in range(NettingChannelContract.locked_time):
+    for _ in range(NettingChannelContract.settle_timeout):
         chain0.next_block()
 
     chain0.settle(asset_address, nettingcontract_address)
@@ -120,7 +120,7 @@ def test_settled_lock():
     )
 
     # forward the block number to allow settle
-    for _ in range(NettingChannelContract.locked_time):
+    for _ in range(NettingChannelContract.settle_timeout):
         apps[2].raiden.chain.next_block()
 
     apps[1].raiden.chain.settle(asset, nettingcontract_address)

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -170,7 +170,7 @@ def create_network(num_nodes=8, num_assets=1, channels_per_node=3, transport_cla
 
     for app in apps:
         for asset_address in asset_list:
-            app.raiden.setup_asset(asset_address, app.config['min_locktime'])
+            app.raiden.setup_asset(asset_address, app.config['reveal_timeout'])
 
     return apps
 
@@ -227,6 +227,6 @@ def create_sequential_network(num_nodes, deposit, asset, transport_class=None):
             )
 
     for app in apps:
-        app.raiden.setup_asset(asset, app.config['min_locktime'])
+        app.raiden.setup_asset(asset, app.config['reveal_timeout'])
 
     return apps


### PR DESCRIPTION
Timeout parameters were hard-coded before, in order to have a more configurable setup they were implemented in the default [config](https://github.com/brainbot-com/raiden/blob/1007f6ed06ed26dafa42d2c91e69dc99cb9f5c1d/raiden/app.py#L28-L31).
The config is accessed by other modules of the program from the [RaidenService](https://github.com/brainbot-com/raiden/blob/1007f6ed06ed26dafa42d2c91e69dc99cb9f5c1d/raiden/raiden_service.py#L90
).

In order to provide better readability of the code and providing a uniform wording, some parameters were renamed:

**reveal_timeout**  (formerly known as *min_locktime* or *hop_timeout*):
 The timespan a node requires to learn the secret before the lock expires for him (time in number of blocks)

**settle_timeout** (formerly known as *locked_time*):
The time of the challenging/settling-period in the NettingChannelContract (time in number of blocks)

**msg_timeout** (formerly referred to as *timeout*):
How long to wait for a transfer until CancelTransfer is sent/ `gevent.wait(msg_timeout)`  (time in milliseconds)